### PR TITLE
Modified header language for image uploads

### DIFF
--- a/app/controllers/public/application.py
+++ b/app/controllers/public/application.py
@@ -68,8 +68,8 @@ def application_image():
     accepted_files = get_cfg()["allowed_extensions"]
     accepted_files = "." + ",.".join(accepted_files)
 
-    new_files_message = "Please upload your images"
-    existing_files_message = "You previous uploaded the following images"
+    new_files_message = "Please upload your images. Please include a document describing the images as well. "
+    existing_files_message = "You previously uploaded the following images"
     form = Forms.get(Forms.fid == fid)
     pre_exist = False
     files = FormToFileQueries.get_form_files(fid)

--- a/app/controllers/public/application.py
+++ b/app/controllers/public/application.py
@@ -26,8 +26,8 @@ def application_statement():
     fid = session["form_id"]
     accepted_files = get_cfg()["document_extensions"]
     accepted_files = "." + ",.".join(accepted_files)
-    new_files_message = "Please upload your artistic statement"
-    existing_files_message = "You previous uploaded the following artistic statement"
+    new_files_message = "Please upload your artist statement"
+    existing_files_message = "You previously uploaded the following artist statement"
     form = Forms.get(Forms.fid == fid)
     pre_exist = False
     if form.personal_statement is not None:
@@ -68,7 +68,7 @@ def application_image():
     accepted_files = get_cfg()["allowed_extensions"]
     accepted_files = "." + ",.".join(accepted_files)
 
-    new_files_message = "Please upload your images. Please include a document describing the images as well. "
+    new_files_message = "Please upload your images along with a list describing them."
     existing_files_message = "You previously uploaded the following images"
     form = Forms.get(Forms.fid == fid)
     pre_exist = False
@@ -116,7 +116,7 @@ def application_cv():
     accepted_files = "." + ",.".join(accepted_files)
 
     new_files_message = "Please upload your curriculum vitae"
-    existing_files_message = "You previous uploaded the following curriculum vitae"
+    existing_files_message = "You previously uploaded the following curriculum vitae"
     form = Forms.get(Forms.fid == fid)
     pre_exist = False
     if form.cv is not None:


### PR DESCRIPTION
Could not run the application. Setup script failed miserably within C9. Lots of installs did not happen. Looks like it's related to an old setuptools in C9, possibly? Either way, setup script is unusable in it's current state.

However, this was a simple language change for the page. It should not break anything.

No issue related to this request; it's in my email.